### PR TITLE
added support for custom user model

### DIFF
--- a/document_library/models.py
+++ b/document_library/models.py
@@ -13,6 +13,7 @@ from hvad.models import TranslatedFields, TranslatableModel, TranslationManager
 from filer.fields.file import FilerFileField
 from filer.fields.image import FilerImageField
 from filer.fields.folder import FilerFolderField
+from django.conf import settings
 
 
 class Attachment(models.Model):
@@ -152,7 +153,7 @@ class Document(TranslatableModel):
     )
 
     user = models.ForeignKey(
-        'auth.User',
+        settings.AUTH_USER_MODEL,
         verbose_name=_('User'),
         null=True, blank=True,
     )


### PR DESCRIPTION
I found it to be the case that this app hard-codes auth.User into the foreignkey.  This change allows the use of custom user models for projects using this app. 
