### PR TITLE
fix to user module migrations: change uUSER to USER

### DIFF
--- a/document_library/migrations/0024_auto__add_field_document_image.py
+++ b/document_library/migrations/0024_auto__add_field_document_image.py
@@ -48,7 +48,7 @@ class Migration(SchemaMigration):
             u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
             'name': ('django.db.models.fields.CharField', [], {'max_length': '50'})
         },
-        uUSER_MODEL['model_label']: {
+        USER_MODEL['model_label']: {
             'Meta': {'object_name': USER_MODEL['object_name']},
             'date_joined': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
             'email': ('django.db.models.fields.EmailField', [], {'max_length': '75', 'blank': 'True'}),

--- a/document_library/migrations/0025_auto__add_field_document_folder.py
+++ b/document_library/migrations/0025_auto__add_field_document_folder.py
@@ -48,7 +48,7 @@ class Migration(SchemaMigration):
             u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
             'name': ('django.db.models.fields.CharField', [], {'max_length': '50'})
         },
-        uUSER_MODEL['model_label']: {
+        USER_MODEL['model_label']: {
             'Meta': {'object_name': USER_MODEL['object_name']},
             'date_joined': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
             'email': ('django.db.models.fields.EmailField', [], {'max_length': '75', 'blank': 'True'}),


### PR DESCRIPTION
Hi, thanks for merging the USER_MODEL updates!  It looks like an extra 'u' got added to the USER_MODEL in some of the migrations.  Simple fix. 
